### PR TITLE
Extend CLI functionality and add bin entry to package

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,17 +2,17 @@
 
 ### Motivation
 
-`yarn` (of course) installs "indirect" or "transitive" dependencies for packages it installs, and it also writes these dependencies to the `yarn.lock` file. 
+`yarn` (of course) installs "indirect" or "transitive" dependencies for packages it installs, and it also writes these dependencies to the `yarn.lock` file.
 
-However, a later `yarn upgrade` will only check _direct_ dependencies. Only when a _direct_ dependency is upgraded to another version, its transitive dependencies are evaluated and upgraded as well. 
+However, a later `yarn upgrade` will only check _direct_ dependencies. Only when a _direct_ dependency is upgraded to another version, its transitive dependencies are evaluated and upgraded as well.
 
 This means, for example, that
 * when you install a package A that has a dependency on some other package B,
 * and B fixes a security issue and creates a new version for the fix,
-* `yarn upgrade` is _not_ going to update B for you 
+* `yarn upgrade` is _not_ going to update B for you
 * _until_ A releases a newer version and you upgrade to it.
 
-As of writing, there is no direct way to make `yarn` upgrade indirect dependencies as well. This is discussed as a feature request in [yarnpkg/yarn#4986](https://github.com/yarnpkg/yarn#4986) (opened 11/2017). 
+As of writing, there is no direct way to make `yarn` upgrade indirect dependencies as well. This is discussed as a feature request in [yarnpkg/yarn#4986](https://github.com/yarnpkg/yarn#4986) (opened 11/2017).
 
 The script in this repository tries to provide an easy-to-use workaround.
 
@@ -24,15 +24,37 @@ The idea is that for packages that you don't specify as your own (direct) depend
 
 ### Usage
 
-In the directory containing your `yarn.lock` file, run 
+In the directory containing your `yarn.lock` file, run via `npx`
 
 ```bash
-node ../path/to/unlock-indirect-yarn-dependencies/dist/index.js
+npx yarn-unlock-indirect-dependencies
 (... prints unlocked packages ...)
+```
+
+or globally install and run
+
+```bash
+npm install -g yarn-unlock-indirect-dependencies
+# or
+yarn global add yarn-unlock-indirect-dependencies
+
+yarn-unlock-indirect-dependencies
+(... prints unlocked packages ...)
+```
+
+then run install to finish the process
+
+```bash
 yarn install
 ```
 
 The first step will remove indirect dependencies from the `yarn.lock` file, and the subsequent `yarn install` will take care of resolving and updating the indirect dependencies again.
+
+You can optionally provide a path to your project's directory if the command is run outside of the the project.
+
+```bash
+yarn-unlock-indirect-dependencies path/to/your/project
+```
 
 Don't forget to commit the updated `yarn.lock` file to version control.
 

--- a/index.js
+++ b/index.js
@@ -1,8 +1,11 @@
+#!/usr/bin/env node
 const fs = require('fs');
+const path = require('path')
 const lockfile = require('@yarnpkg/lockfile');
-const package = require(process.cwd() + '/package.json');
-const lock = lockfile.parse(fs.readFileSync('yarn.lock', 'utf-8')).object;
 
+const directory = process.argv[2] || ''
+const package = JSON.parse(fs.readFileSync(path.join(directory, 'package.json'), 'utf-8'));
+const lock = lockfile.parse(fs.readFileSync(path.join(directory, 'yarn.lock'), 'utf-8')).object;
 const allDeps = new Set();
 
 const parseDep = ([name, version]) => {
@@ -18,7 +21,7 @@ const newLock = Object.fromEntries(Object.entries(lock).filter(([dep]) => {
   if (allDeps.has(dep)) {
     return true;
   }
-  
+
   console.log(`Unlocking ${dep}`);
 
   return false;
@@ -26,6 +29,6 @@ const newLock = Object.fromEntries(Object.entries(lock).filter(([dep]) => {
 
 const newLockString = lockfile.stringify(newLock);
 
-fs.writeFileSync('yarn.lock', newLockString);
+fs.writeFileSync(path.join(directory, 'yarn.lock'), newLockString);
 
 console.log("Done. Don't forget to run 'yarn install'!");

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "yarn-unlock-indirect-dependencies",
   "version": "0.1.0",
   "main": "index.js",
+  "bin": {
+    "yarn-unlock-indirect-dependencies": "./index.js"
+  },
   "license": "MIT",
   "dependencies": {
     "@yarnpkg/lockfile": "^1.1.0"


### PR DESCRIPTION
I originally was just going to add the bin entry, but figured it'd be useful to add a command line argument for a path to the project to work against

VS Code automatically removed extra whitespace from some of the files, I can revert that if desired